### PR TITLE
fix: temp fix to send existing user from login to dater profile

### DIFF
--- a/screens/LoginEmail.tsx
+++ b/screens/LoginEmail.tsx
@@ -33,7 +33,8 @@ export default function LoginEmail() {
             setIsLoading(true);
             // TODO: Implement login API with rate limiting
             // await loginUser({ email, password });
-            router.replace('/(account)/profile');
+            // TODO: Send user to either a dater profile or a friend profile
+            router.replace('/(account)/daterprofile');
         
         } catch (_err) {
             setError('Invalid email or password');  // Don't expose specific errors


### PR DESCRIPTION
Route was broken from existing user login to profile. Put in a temp fix to send user to dater profile with a "TODO" to update once there is a friend profile. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the post-login experience so that users are now directed to a dedicated "dater profile" page instead of a generic profile page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->